### PR TITLE
fix(drizzle-kit): replace deprecated `:pg` scripts with `generate` and `push`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-storybook": "storybook build",
     "clean": "node scripts/clean.js",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit push:pg",
+    "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx scripts/seed.ts",
     "db:studio": "drizzle-kit studio",
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "next build",
     "build-storybook": "storybook build",
     "clean": "node scripts/clean.js",
-    "db:generate": "drizzle-kit generate:pg",
+    "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit push:pg",
     "db:seed": "tsx scripts/seed.ts",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
### Summary
Replace deprecated Drizzle Kit `:pg` scripts with the supported adapter-agnostic commands.

### Context
Since Drizzle Kit v0.21.x, the old `:pg` shorthands are deprecated/removed.
- `drizzle-kit :pg` → **`drizzle-kit generate`**
- `drizzle-kit push:pg` → **`drizzle-kit push`**

### Changes
Update `package.json`:
```diff
- "db:generate": "drizzle-kit :pg"
+ "db:generate": "drizzle-kit generate"

- "db:push": "drizzle-kit push:pg"
+ "db:push": "drizzle-kit push"

<img width="1084" height="322" alt="image" src="https://github.com/user-attachments/assets/2b6063a3-174e-4204-847f-e1d4ec952f8e" />
<img width="1085" height="255" alt="image" src="https://github.com/user-attachments/assets/349e05a1-cf39-4f18-8784-4770fca1d0d4" />



### Testing

**Environment**
- OS: Windows 11
- Node: v21.1.0
- npm: 10.2.3
- Drizzle Kit: v0.21.x

**Command**
```bash
npm run db:generate

> nextjs-boilerplate@1.0.0 db:generate
> drizzle-kit generate

No config path provided, using default 'drizzle.config.ts'
Reading config file 'D:\dev\sandbox\nextjs-starter-template\drizzle.config.ts'
1 tables
users 4 columns 0 indexes 0 fks

No schema changes, nothing to migrate 😴
