### PR TITLE
docs: refresh README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # 🚀 Next.js Starter Template
 
-A production-ready Next.js boilerplate with modern tooling, comprehensive testing, and enterprise-grade features.
-### ⭐ **Star this repository if it helped you!** 
+A production-ready Next.js boilerplate with modern tooling, comprehensive testing, and enterprise-grade starter features.
+### ⭐ **Star this repository if it helped you!**
 
-> 💫 **Built with love by [Yeasin](https://github.com/yeasin2002)**  and other contributor
+> 💫 **Built with love by [Yeasin](https://github.com/yeasin2002)** and other contributor
 
-##### If you found  any issue or have any suggestion, please open an [issue](https://github.com/yeasin2002/nextjs-starter-template/issues) or a [pull request](https://github.com/yeasin2002/nextjs-starter-template/pulls).
+##### If you found any issue or have any suggestion, please open an [issue](https://github.com/yeasin2002/bulletproof-nextjs-starter/issues) or a [pull request](https://github.com/yeasin2002/bulletproof-nextjs-starter/pulls).
 
 ##### Feel free to reach out to me on [Linkedin](https://www.linkedin.com/in/yeasin2002/) or [Gmail](mailto:mdkawsarislam2002@gmail.com) if you have any questions or feedback.
 
@@ -29,8 +29,8 @@ A production-ready Next.js boilerplate with modern tooling, comprehensive testin
 - 🎛️ **Drizzle Studio** for database management
 
 ### 🔐 **Authentication**
-- 👤 **better-auth** integration for auth  management
-- 🔒 **Secure** authentication flows
+- 👤 **Authentication-ready** starter types, validations, and constants
+- 🔒 **Starter** auth test scaffolding for future secure flows
 - 📧 **Email templates** with React Email
 
 ### 🌍 **Internationalization**
@@ -38,8 +38,8 @@ A production-ready Next.js boilerplate with modern tooling, comprehensive testin
 - 🌐 **Locale routing** and translations
 
 ### 🧪 **Testing Suite**
-- ⚡ **Vitest** for unit testing with jsdom
-- 🎭 **Playwright** for E2E testing
+- ⚡ **Vitest** setup for unit testing with jsdom
+- 🎭 **Playwright** setup for E2E testing
 - 🧪 **Testing Library** for React components
 - 📚 **Storybook** for component development
 - 📊 **Coverage reports** with v8
@@ -67,6 +67,7 @@ A production-ready Next.js boilerplate with modern tooling, comprehensive testin
 
 ### Prerequisites
 - Node.js 18+ or Bun
+- pnpm (recommended)
 - PostgreSQL database
 - Git
 
@@ -74,14 +75,12 @@ A production-ready Next.js boilerplate with modern tooling, comprehensive testin
 
 ```bash
 # Clone the repository
-git clone https://github.com/yeasin2002/nextjs-starter-template.git
-cd nextjs-starter-template
+git clone https://github.com/yeasin2002/bulletproof-nextjs-starter.git
+cd bulletproof-nextjs-starter
 
-# Quick setup (recommended)
-npm run setup
-
-# Or manual setup:
 # Install dependencies
+pnpm install
+# or
 npm install
 # or
 bun install
@@ -112,7 +111,6 @@ Visit [http://localhost:3000](http://localhost:3000) to see your application.
 
 ### 🔧 **Development**
 ```bash
-npm run setup        # Quick project setup
 npm run dev          # Start development server
 npm run build        # Build for production
 npm run start        # Start production server
@@ -173,23 +171,25 @@ npm run analyze      # Analyze bundle size
 ## 📁 Project Structure
 
 ```
-├── .kiro/              # Kiro AI assistant configuration
-├── .storybook/         # Storybook configuration
-├── config/             # Application configuration
-├── public/             # Static assets
+├── .agents/             # Agent skills and workflow configuration
+├── .github/             # GitHub workflows and repository settings
+├── .storybook/          # Storybook configuration
+├── public/              # Static assets
+├── scripts/             # Build and deployment scripts
 ├── src/
-│   ├── app/            # Next.js App Router pages
-│   ├── components/     # Reusable React components
-│   │   └── ui/         # shadcn/ui components
-│   ├── db/             # Database configuration & schema
-│   ├── hooks/          # Custom React hooks
-│   ├── i18n/           # Internationalization
-│   ├── lib/            # Utility libraries
-│   ├── styles/         # Global CSS
-│   ├── types/          # TypeScript definitions
-│   └── utils/          # Helper functions
-├── tests/              # E2E and integration tests
-└── scripts/            # Build and deployment scripts
+│   ├── app/             # Next.js App Router pages
+│   ├── components/      # Reusable React components
+│   │   └── ui/          # shadcn/ui components
+│   ├── db/              # Database configuration & schema
+│   ├── hooks/           # Custom React hooks
+│   ├── i18n/            # Internationalization
+│   ├── lib/             # Utility libraries
+│   ├── styles/          # Global CSS
+│   ├── types/           # TypeScript definitions
+│   └── utils/           # Helper functions
+├── tests/               # E2E and integration tests
+├── pnpm-lock.yaml       # pnpm lockfile
+└── pnpm-workspace.yaml  # pnpm workspace configuration
 ```
 
 ## 🔧 Configuration
@@ -205,7 +205,8 @@ Copy `.env.example` to `.env` and configure:
 3. Optional: Seed data: `npm run db:seed`
 
 ### Authentication
-- Better Auth 
+- Authentication-ready starter scaffolding is included for types, validations, constants, tests, and email templates.
+- Complete auth pages and runtime integration are not wired up yet in the current app.
 
 ## 🚀 Deployment
 
@@ -242,5 +243,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [shadcn/ui](https://ui.shadcn.com/) - Beautiful UI components
 - [Drizzle ORM](https://orm.drizzle.team/) - TypeScript ORM
 ---
-
-


### PR DESCRIPTION
## Summary

This PR refreshes the README to better match the current state of the repository.

### What changed
- Updated repository links to `yeasin2002/bulletproof-nextjs-starter`
- Updated the clone command and project directory name
- Removed the broken `npm run setup` flow from Quick Start and Available Scripts
- Added `pnpm install` as the recommended install path
- Updated the project structure section to match the actual repository layout
- Adjusted authentication/testing wording so it reflects the current starter/scaffolding state more accurately

## Why

The previous README still referenced:
- the old repository name and links
- a setup script that does not exist
- an outdated project structure
- auth wording that implied more implementation than is currently wired in the app

